### PR TITLE
Gabe allow missing app

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ An automated build of master is available at [registry.hub.docker.com/u/byxorna/
 ```
 # docker run -it byxorna/goji -h
 Usage of ./goji:
-  -conf="": config json file
-  -server=false: start a HTTP server listening for Marathon events
-  -target="": target file to write to
+  -app-required=false: Require marathon applications to exist (assumes no tasks for missing apps if false)
+  -conf="": Config JSON file
+  -server=false: Start a HTTP server listening for Marathon events
+  -target="": Target file to write to
 ```
 
 ## Configuration
@@ -159,9 +160,10 @@ And config:
 $ go build
 $ ./goji -help
 Usage of ./goji:
-  -conf="": config json file
-  -server=false: start a HTTP server listening for Marathon events
-  -target="": target file to write to
+  -app-required=false: Require marathon applications to exist (assumes no tasks for missing apps if false)
+  -conf="": Config JSON file
+  -server=false: Start a HTTP server listening for Marathon events
+  -target="": Target file to write to
 ```
 
 ## More information

--- a/main.go
+++ b/main.go
@@ -19,16 +19,18 @@ var (
 	// current state of services we know about
 	services ServiceList
 	// listen to this channel for update triggers
-	eventChan chan string
-	client    marathon.Client
-	sigChan   chan os.Signal
-	server    bool
+	eventChan           chan string
+	client              marathon.Client
+	sigChan             chan os.Signal
+	server              bool
+	appPresenceRequired bool
 )
 
 func init() {
-	flag.StringVar(&configPath, "conf", "", "config json file")
-	flag.BoolVar(&server, "server", false, "start a HTTP server listening for Marathon events")
-	flag.StringVar(&target, "target", "", "target file to write to")
+	flag.StringVar(&configPath, "conf", "", "Config JSON file")
+	flag.BoolVar(&server, "server", false, "Start a HTTP server listening for Marathon events")
+	flag.StringVar(&target, "target", "", "Target file to write to")
+	flag.BoolVar(&appPresenceRequired, "app-required", false, "Require marathon applications to exist (assumes no tasks for missing apps if false)")
 	flag.Parse()
 }
 

--- a/service.go
+++ b/service.go
@@ -30,7 +30,7 @@ type ServiceList []Service
 // and clobber each service in the ServiceList's Tasks with a new set
 func (services *ServiceList) LoadAllAppTasks(c marathon.Client) error {
 	for i, service := range *services {
-		ts, err := c.GetTasks(service.AppId)
+		ts, err := c.GetTasks(service.AppId, appPresenceRequired)
 		if err != nil {
 			return err
 		}
@@ -59,8 +59,8 @@ func NewService(cfg ConfigService) (Service, error) {
 	if cfg.Protocol == "" {
 		cfg.Protocol = HTTP
 	}
-  // just accept the protocol given if we dont recognize it? Could be someone using a strange
-  // proto for SRV records like ldap or so on.
+	// just accept the protocol given if we dont recognize it? Could be someone using a strange
+	// proto for SRV records like ldap or so on.
 	if cfg.Port == 0 {
 		// just assume port 80 if not specified
 		cfg.Port = 80


### PR DESCRIPTION
@primer42 this will allow goji to let missing applications act as though they have no tasks. Controllable via the `-app-required` flag, defaults to false (treat 404 on `GET /v2/apps/{appId}/tasks` as empty tasks)
